### PR TITLE
feat(node): add sandboxed npm and pnpm workflows (#27)

### DIFF
--- a/src/main/agent.ts
+++ b/src/main/agent.ts
@@ -459,6 +459,7 @@ export async function develop(
       `The project Python environment is stored under folder ID ${project.pythonEnvironmentFolderId}.`,
       'Inspect relevant files before editing. Prefer file_patch for a unique local change and write_file for complete file creation or replacement.',
       'Use file and project tools for general development work. Use Python tools only for Python-related tasks or explicit Python environment operations.',
+      'For JavaScript or TypeScript projects, use node_package_command for npm/pnpm dependency operations and node_package_script only for scripts explicitly defined in package.json; do not run arbitrary package-manager shell commands.',
       'Every tool is restricted to the project sandbox. Do not access .git, agent_venv, or cache directories directly; use git_* tools for version control.',
       'Git tools only operate on attached folders that are repository roots. git_add requires explicit file paths, and git_commit requires staged changes.',
       'Hot context is the only context sent to you. Messages are never compressed while resident in Hot; recalled summaries remain explicitly labeled and non-authoritative. Warm context is never sent directly.',

--- a/src/main/node-sandbox.ts
+++ b/src/main/node-sandbox.ts
@@ -1,0 +1,351 @@
+import { access, mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import {
+  runSandboxProcess,
+  safeResolveExistingPath,
+  safeResolveWritablePath,
+  truncateOutput,
+  type SandboxProcessResult,
+} from './sandbox'
+
+export type PackageManager = 'npm' | 'pnpm'
+export type PackageCommand = 'install' | 'ci' | 'update' | 'list' | 'outdated'
+
+export type NodePackageExecutionResult = {
+  success: boolean
+  stdout: string
+  stderr: string
+  exit_code: number
+  duration_ms: number
+  timed_out: boolean
+}
+
+const maxArgumentLength = 500
+const maxPackageCount = 20
+
+const nodeGuardSource = String.raw`
+const fs = require('node:fs')
+const path = require('node:path')
+const { fileURLToPath } = require('node:url')
+
+const sandboxRoot = path.resolve(process.env.CODEY_NODE_SANDBOX_ROOT || process.cwd())
+const enforce = Boolean(process.env.npm_lifecycle_event)
+const originalExistsSync = fs.existsSync.bind(fs)
+const originalRealpathNative = fs.realpath.native
+const originalRealpathSyncNative = (fs.realpathSync.native || fs.realpathSync).bind(fs.realpathSync)
+const allowedReadRoots = [
+  path.dirname(process.execPath),
+  ...(process.env.CODEY_NODE_ALLOWED_READ_ROOTS || '').split(path.delimiter).filter(Boolean),
+].map((value) => path.resolve(value))
+const allowedWriteRoots = [
+  sandboxRoot,
+  ...(process.env.CODEY_NODE_ALLOWED_WRITE_ROOTS || '').split(path.delimiter).filter(Boolean),
+].map((value) => path.resolve(value))
+const blockedNames = new Set(['.git', 'agent_venv'])
+
+function isWithin(root, target) {
+  const relativePath = path.relative(root, target)
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+}
+
+function resolvePath(value) {
+  if (typeof value === 'number') return null
+  if (value instanceof URL) value = fileURLToPath(value)
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) value = value.toString()
+  if (typeof value !== 'string') return null
+  const target = path.resolve(process.cwd(), value)
+  let current = target
+  while (!originalExistsSync(current)) {
+    const parent = path.dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  try {
+    return path.join(originalRealpathSyncNative(current), path.relative(current, target))
+  } catch {
+    return target
+  }
+}
+
+function assertPath(value, write) {
+  if (!enforce) return
+  const target = resolvePath(value)
+  if (!target) return
+  const parts = path.relative(sandboxRoot, target).split(/[\\/]+/)
+  if (parts.some((part) => blockedNames.has(part.toLowerCase()))) {
+    throw new Error('Node sandbox denied access to a protected project path')
+  }
+  if (write ? !allowedWriteRoots.some((root) => isWithin(root, target)) : !isWithin(sandboxRoot, target) && !allowedReadRoots.some((root) => isWithin(root, target))) {
+    throw new Error('Node sandbox denied access outside the package workspace')
+  }
+}
+
+function wrap(target, name, indexes, write = false) {
+  const original = target[name]
+  if (typeof original !== 'function') return
+  target[name] = function (...args) {
+    for (const index of indexes) assertPath(args[index], write)
+    return original.apply(this, args)
+  }
+}
+
+for (const name of [
+  'readFile', 'readFileSync', 'readdir', 'readdirSync', 'stat', 'statSync', 'lstat', 'lstatSync',
+  'access', 'accessSync', 'realpath', 'realpathSync', 'existsSync', 'createReadStream',
+]) wrap(fs, name, [0])
+for (const name of [
+  'writeFile', 'writeFileSync', 'appendFile', 'appendFileSync', 'mkdir', 'mkdirSync',
+  'rm', 'rmSync', 'rmdir', 'rmdirSync', 'unlink', 'unlinkSync', 'truncate', 'truncateSync',
+  'chmod', 'chmodSync', 'utimes', 'utimesSync', 'createWriteStream',
+]) wrap(fs, name, [0], true)
+for (const name of ['rename', 'renameSync', 'copyFile', 'copyFileSync', 'link', 'linkSync', 'cp', 'cpSync']) {
+  wrap(fs, name, [0, 1], true)
+}
+for (const name of ['open', 'openSync']) wrap(fs, name, [0])
+// Preserve Node's native realpath helpers used by package-manager internals.
+if (originalRealpathNative) fs.realpath.native = originalRealpathNative
+if (originalRealpathSyncNative) fs.realpathSync.native = originalRealpathSyncNative
+
+const promises = fs.promises
+for (const name of [
+  'readFile', 'readdir', 'stat', 'lstat', 'access', 'realpath', 'open',
+]) wrap(promises, name, [0])
+for (const name of [
+  'writeFile', 'appendFile', 'mkdir', 'rm', 'rmdir', 'unlink', 'truncate', 'chmod', 'utimes',
+]) wrap(promises, name, [0], true)
+for (const name of ['rename', 'copyFile', 'link', 'cp']) wrap(promises, name, [0, 1], true)
+
+const childProcess = require('node:child_process')
+function checkChildOptions(options) {
+  if (options && typeof options === 'object' && options.cwd !== undefined) assertPath(options.cwd, false)
+}
+for (const name of ['spawn', 'spawnSync', 'exec', 'execSync', 'execFile', 'execFileSync', 'fork']) {
+  const original = childProcess[name]
+  if (typeof original !== 'function') continue
+  childProcess[name] = function (...args) {
+    const optionsIndex = name.startsWith('exec') || name === 'fork' ? 1 : 2
+    checkChildOptions(args[optionsIndex])
+    return original.apply(this, args)
+  }
+}
+
+const originalChdir = process.chdir
+process.chdir = function (directory) {
+  assertPath(directory, false)
+  return originalChdir.call(this, directory)
+}
+`
+
+function normalizeTimeout(timeoutSeconds: number): number {
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds < 1 || timeoutSeconds > 120) {
+    throw new Error('timeout must be between 1 and 120 seconds')
+  }
+  return Math.round(timeoutSeconds * 1000)
+}
+
+function assertPackageManager(value: string): asserts value is PackageManager {
+  if (value !== 'npm' && value !== 'pnpm') {
+    throw new Error('package_manager must be npm or pnpm')
+  }
+}
+
+function assertPackageCommand(value: string): asserts value is PackageCommand {
+  if (!['install', 'ci', 'update', 'list', 'outdated'].includes(value)) {
+    throw new Error('command must be install, ci, update, list, or outdated')
+  }
+}
+
+function packagePathCandidates(manager: PackageManager): string[] {
+  const directories = (process.env.PATH ?? '').split(';').filter(Boolean)
+  return directories.flatMap((directory) => [
+    join(directory, `${manager}.cmd`),
+    join(directory, `${manager}.exe`),
+    join(directory, manager),
+  ])
+}
+
+async function managerInvocation(manager: PackageManager): Promise<{ command: string; prefixArgs: string[]; readRoot: string }> {
+  if (process.platform !== 'win32') {
+    return { command: manager, prefixArgs: [], readRoot: dirname(process.execPath) }
+  }
+
+  for (const candidate of packagePathCandidates(manager)) {
+    try {
+      await access(candidate)
+      if (!candidate.toLowerCase().endsWith('.cmd')) {
+        return { command: candidate, prefixArgs: [], readRoot: dirname(candidate) }
+      }
+      const shim = await readFile(candidate, 'utf8')
+      const cli = shim.match(/"%dp0%\\([^"\r\n]*node_modules\\(?:npm|pnpm)\\[^"\r\n]+)"/i)?.[1]
+      if (cli) {
+        const root = dirname(candidate)
+        const cliPath = join(root, cli)
+        let readRoot = root
+        try {
+          readRoot = await realpath(dirname(dirname(dirname(dirname(cliPath)))))
+        } catch {
+          // Keep the shim directory when the package path cannot be resolved.
+        }
+        return {
+          command: join(root, 'node.exe'),
+          prefixArgs: [cliPath],
+          readRoot,
+        }
+      }
+    } catch {
+      // Try the next PATH entry.
+    }
+  }
+  throw new Error(`Unable to locate ${manager}; install it or add it to PATH`)
+}
+
+function isSafePackageSpecifier(value: string): boolean {
+  return new RegExp('^(?:@[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*)(?:@[a-z0-9*^~<>=|._+-]+)?$', 'i').test(value)
+}
+
+function validatePackages(packages: string[]): void {
+  if (packages.length > maxPackageCount || packages.some((item) => (
+    typeof item !== 'string' || item.length === 0 || item.length > maxArgumentLength || !isSafePackageSpecifier(item)
+  ))) {
+    throw new Error('packages must contain at most 20 valid registry package specifiers')
+  }
+}
+
+function validateArguments(argv: string[]): void {
+  if (argv.length > 20 || argv.some((item) => typeof item !== 'string' || item.length > maxArgumentLength || /[\r\n]/.test(item))) {
+    throw new Error('argv must contain at most 20 short arguments')
+  }
+}
+
+function resultFromProcess(result: SandboxProcessResult): NodePackageExecutionResult {
+  return {
+    success: !result.timedOut && result.exitCode === 0,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exit_code: result.timedOut ? -1 : (result.exitCode ?? -1),
+    duration_ms: result.durationMs,
+    timed_out: result.timedOut,
+  }
+}
+
+async function prepareNodeSandbox(root: string, withGuard = true): Promise<{ guardPath?: string; temporaryDirectory: string }> {
+  const temporaryDirectory = await safeResolveWritablePath(root, '.agent_tmp')
+  await mkdir(temporaryDirectory, { recursive: true })
+  if (!withGuard) return { temporaryDirectory }
+  const guardPath = await safeResolveWritablePath(root, '.agent_tmp/node-sandbox-guard.cjs')
+  await writeFile(guardPath, nodeGuardSource, 'utf8')
+  return { guardPath, temporaryDirectory }
+}
+
+function sandboxEnvironment(root: string, temporaryDirectory: string, managerRoot: string, guardPath?: string): NodeJS.ProcessEnv {
+  const inheritedEnvironment = Object.fromEntries(
+    ['PATH', 'Path', 'SystemRoot', 'ComSpec', 'COMSPEC', 'PATHEXT', 'LOCALAPPDATA', 'APPDATA', 'ProgramData', 'HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'NODE_EXTRA_CA_CERTS']
+      .filter((key) => process.env[key] !== undefined)
+      .map((key) => [key, process.env[key] as string]),
+  )
+  const environment: NodeJS.ProcessEnv = {
+    ...inheritedEnvironment,
+    NODE_ENV: process.env.NODE_ENV ?? 'development',
+    npm_config_global: 'false',
+    npm_config_ignore_scripts: 'true',
+    npm_config_audit: 'false',
+    npm_config_fund: 'false',
+    npm_config_update_notifier: 'false',
+    npm_config_cache: join(temporaryDirectory, 'npm-cache'),
+    npm_config_tmp: temporaryDirectory,
+    npm_config_userconfig: join(temporaryDirectory, '.npmrc'),
+    npm_config_globalconfig: join(temporaryDirectory, '.npm-globalrc'),
+    pnpm_config_global: 'false',
+    pnpm_config_ignore_scripts: 'true',
+    pnpm_config_store_dir: join(temporaryDirectory, 'pnpm-store'),
+    PNPM_HOME: temporaryDirectory,
+    TEMP: temporaryDirectory,
+    TMP: temporaryDirectory,
+    TMPDIR: temporaryDirectory,
+    HOME: temporaryDirectory,
+    USERPROFILE: temporaryDirectory,
+    XDG_CACHE_HOME: temporaryDirectory,
+    CODEY_NODE_SANDBOX_ROOT: root,
+    CODEY_NODE_ALLOWED_READ_ROOTS: [managerRoot, temporaryDirectory].join(process.platform === 'win32' ? ';' : ':'),
+    CODEY_NODE_ALLOWED_WRITE_ROOTS: temporaryDirectory,
+  }
+  if (guardPath) {
+    environment.NODE_OPTIONS = '--require=' + guardPath.replaceAll('\\', '/')
+  } else {
+    delete environment.NODE_OPTIONS
+  }
+  return environment
+}
+
+async function readPackageScripts(root: string): Promise<Record<string, string>> {
+  let raw: string
+  try {
+    raw = await readFile(join(root, 'package.json'), 'utf8')
+  } catch {
+    throw new Error('package.json was not found in the selected project folder')
+  }
+  let manifest: unknown
+  try {
+    manifest = JSON.parse(raw)
+  } catch {
+    throw new Error('package.json is not valid JSON')
+  }
+  const scripts = (manifest as { scripts?: unknown })?.scripts
+  if (!scripts || typeof scripts !== 'object' || Array.isArray(scripts)) return {}
+  return Object.fromEntries(Object.entries(scripts).filter((entry): entry is [string, string] => typeof entry[1] === 'string'))
+}
+
+export async function runPackageManagerCommand(
+  projectRoot: string,
+  packageManager: PackageManager,
+  command: PackageCommand,
+  packages: string[] = [],
+  timeoutSeconds = 120,
+  signal?: AbortSignal,
+): Promise<NodePackageExecutionResult> {
+  assertPackageManager(packageManager)
+  assertPackageCommand(command)
+  validatePackages(packages)
+  if (command === 'ci' && packages.length > 0) throw new Error('packages are not supported with the ci command')
+  if ((command === 'list' || command === 'outdated') && packages.length > 0) throw new Error(`packages are not supported with the ${command} command`)
+  const root = await safeResolveExistingPath(projectRoot, '.')
+  const { command: executable, prefixArgs, readRoot } = await managerInvocation(packageManager)
+  const { temporaryDirectory } = await prepareNodeSandbox(root, false)
+  const args: string[] = [...prefixArgs, command]
+  if (packageManager === 'pnpm' && command === 'ci') {
+    args.splice(args.length - 1, 1, 'install')
+    args.push('--frozen-lockfile', '--ignore-scripts')
+  } else if (command === 'install' || command === 'ci' || command === 'update') {
+    args.push('--ignore-scripts')
+  }
+  if (command === 'install' || command === 'update') args.push(...packages)
+  const result = await runSandboxProcess(executable, args, root, normalizeTimeout(timeoutSeconds), sandboxEnvironment(root, temporaryDirectory, readRoot), undefined, signal)
+  return resultFromProcess(result)
+}
+
+export async function runPackageScript(
+  projectRoot: string,
+  packageManager: PackageManager,
+  script: string,
+  argv: string[] = [],
+  timeoutSeconds = 120,
+  signal?: AbortSignal,
+): Promise<NodePackageExecutionResult> {
+  assertPackageManager(packageManager)
+  if (!/^[A-Za-z0-9._:-]{1,100}$/.test(script)) throw new Error('script must be a package.json script name')
+  validateArguments(argv)
+  const root = await safeResolveExistingPath(projectRoot, '.')
+  const scripts = await readPackageScripts(root)
+  if (!Object.hasOwn(scripts, script)) throw new Error(`Script '${script}' is not defined in package.json`)
+  const { command: executable, prefixArgs, readRoot } = await managerInvocation(packageManager)
+  const { temporaryDirectory, guardPath } = await prepareNodeSandbox(root)
+  const args: string[] = [...prefixArgs, 'run', script]
+  if (argv.length > 0) args.push('--', ...argv)
+  const result = await runSandboxProcess(executable, args, root, normalizeTimeout(timeoutSeconds), sandboxEnvironment(root, temporaryDirectory, readRoot, guardPath), undefined, signal)
+  return resultFromProcess(result)
+}
+
+export function packageResultSummary(result: NodePackageExecutionResult): string {
+  return truncateOutput(JSON.stringify(result))
+}
+

--- a/src/main/sandbox.ts
+++ b/src/main/sandbox.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import { access, mkdir, realpath, writeFile } from 'node:fs/promises'
 import { dirname, isAbsolute, relative, resolve, win32 } from 'node:path'
 
-type ProcessResult = {
+export type SandboxProcessResult = {
   exitCode: number | null
   stdout: string
   stderr: string
@@ -304,9 +304,23 @@ export async function safeResolveWritablePath(
 }
 
 function killChild(child: ChildProcess): void {
-  if (!child.killed) {
-    child.kill()
+  if (child.killed) return
+  if (process.platform === 'win32' && child.pid) {
+    spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+      windowsHide: true,
+      stdio: 'ignore',
+    })
+    return
   }
+  if (child.pid && process.platform !== 'win32') {
+    try {
+      process.kill(-child.pid, 'SIGKILL')
+      return
+    } catch {
+      // Fall back to terminating the direct child.
+    }
+  }
+  child.kill()
 }
 
 function abortError(): Error {
@@ -319,7 +333,7 @@ function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) throw abortError()
 }
 
-function runProcess(
+export function runSandboxProcess(
   command: string,
   args: string[],
   cwd: string,
@@ -327,7 +341,7 @@ function runProcess(
   env?: NodeJS.ProcessEnv,
   input?: string,
   signal?: AbortSignal,
-): Promise<ProcessResult> {
+): Promise<SandboxProcessResult> {
   return new Promise((resolveProcess, rejectProcess) => {
     if (signal?.aborted) {
       rejectProcess(abortError())
@@ -338,6 +352,7 @@ function runProcess(
       cwd,
       env,
       shell: false,
+      detached: process.platform !== 'win32',
       windowsHide: true,
       stdio: [input === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'],
     })
@@ -426,7 +441,7 @@ async function createVenv(projectRoot: string, signal?: AbortSignal): Promise<vo
   let failure = ''
   for (const candidate of candidates) {
     try {
-      const result = await runProcess(
+      const result = await runSandboxProcess(
         candidate.command,
         [...candidate.args, '-m', 'venv', venvPath(projectRoot)],
         projectRoot,
@@ -515,12 +530,12 @@ async function runSandboxMode(
   cwd: string,
   input?: string,
   signal?: AbortSignal,
-): Promise<ProcessResult> {
+): Promise<SandboxProcessResult> {
   const temporaryDirectory = await safeResolveWritablePath(root, '.agent_tmp')
   await ensurePythonEnvironment(root, signal)
   throwIfAborted(signal)
   await mkdir(temporaryDirectory, { recursive: true })
-  return runProcess(
+  return runSandboxProcess(
     pythonPath(root),
     [...runnerArguments(mode, roots, root), ...modeArgs],
     cwd,
@@ -540,7 +555,7 @@ async function runSandboxMode(
   )
 }
 
-function executionResult(result: ProcessResult, timeoutMs: number): PythonExecutionResult {
+function executionResult(result: SandboxProcessResult, timeoutMs: number): PythonExecutionResult {
   const stderr = result.timedOut
     ? truncateOutput(`${result.stderr}${result.stderr ? '\n' : ''}Execution timed out after ${timeoutMs / 1000} seconds`)
     : result.stderr
@@ -617,7 +632,7 @@ export async function installPythonPackages(
   await ensurePythonEnvironment(root, signal)
   throwIfAborted(signal)
   await mkdir(temporaryDirectory, { recursive: true })
-  const result = await runProcess(
+  const result = await runSandboxProcess(
     pipPath(root),
     ['install', '--isolated', '--disable-pip-version-check', '--no-cache-dir', ...packages],
     root,

--- a/src/main/tools.ts
+++ b/src/main/tools.ts
@@ -20,6 +20,7 @@ import {
   safeResolveWritablePath,
   truncateOutput,
 } from './sandbox'
+import { runPackageManagerCommand, runPackageScript } from './node-sandbox'
 
 export type ToolCall = {
   id: string
@@ -48,6 +49,9 @@ type ToolArguments = {
   max_count?: number
   ids?: string[]
   limit?: number
+  package_manager?: 'npm' | 'pnpm'
+  command?: 'install' | 'ci' | 'update' | 'list' | 'outdated'
+  script?: string
 }
 
 type TreeNode = {
@@ -427,6 +431,58 @@ export async function runAgentTool(
     return stringifyResult(await gitGetCurrentBranch(getFolder(project, args.folder_id).path, runtime?.signal))
   }
 
+  if (toolCall.function.name === 'node_package_command') {
+    if (
+      typeof args.folder_id !== 'string' ||
+      (args.package_manager !== 'npm' && args.package_manager !== 'pnpm') ||
+      !args.command ||
+      typeof args.timeout !== 'number'
+    ) {
+      throw new Error('folder_id, package_manager, command, and timeout are required')
+    }
+    const folder = getFolder(project, args.folder_id)
+    const packageRoot = await resolveFolderPath(folder, args.path ?? '.', false)
+    const packages = args.packages ?? []
+    if (!Array.isArray(packages) || packages.some((item) => typeof item !== 'string')) {
+      throw new Error('packages must be an array of strings')
+    }
+    return stringifyResult(
+      await runPackageManagerCommand(
+        packageRoot,
+        args.package_manager,
+        args.command,
+        packages,
+        args.timeout,
+        runtime?.signal,
+      ),
+    )
+  }
+  if (toolCall.function.name === 'node_package_script') {
+    if (
+      typeof args.folder_id !== 'string' ||
+      (args.package_manager !== 'npm' && args.package_manager !== 'pnpm') ||
+      typeof args.script !== 'string' ||
+      typeof args.timeout !== 'number'
+    ) {
+      throw new Error('folder_id, package_manager, script, and timeout are required')
+    }
+    const folder = getFolder(project, args.folder_id)
+    const packageRoot = await resolveFolderPath(folder, args.path ?? '.', false)
+    const argv = args.argv ?? []
+    if (!Array.isArray(argv) || argv.some((item) => typeof item !== 'string')) {
+      throw new Error('argv must be an array of strings')
+    }
+    return stringifyResult(
+      await runPackageScript(
+        packageRoot,
+        args.package_manager,
+        args.script,
+        argv,
+        args.timeout,
+        runtime?.signal,
+      ),
+    )
+  }
   const environmentFolder = getEnvironmentFolder(project)
   const folderPaths = projectFolderPaths(project)
 
@@ -564,6 +620,8 @@ export function createAgentTools(project: Project): object[] {
     { type: 'function', function: { name: 'list_directory', description: 'List files and directories in a project folder.', parameters: { type: 'object', properties: pathProperties, required: pathRequired, additionalProperties: false } } },
     { type: 'function', function: { name: 'read_file', description: 'Read a UTF-8 text file from a project folder.', parameters: { type: 'object', properties: pathProperties, required: pathRequired, additionalProperties: false } } },
     { type: 'function', function: { name: 'write_file', description: 'Create or replace a UTF-8 code file in a project folder.', parameters: { type: 'object', properties: { ...pathProperties, content: { type: 'string', description: 'Complete file content.' } }, required: [...pathRequired, 'content'], additionalProperties: false } } },
+    { type: 'function', function: { name: 'node_package_command', description: 'Run a safe npm or pnpm package-manager operation in a project package root. Install, CI, and update always disable package lifecycle scripts.', parameters: { type: 'object', properties: { folder_id: folderId, path: { type: 'string', description: 'Optional package directory relative to the selected project folder.' }, package_manager: { type: 'string', enum: ['npm', 'pnpm'] }, command: { type: 'string', enum: ['install', 'ci', 'update', 'list', 'outdated'] }, packages: { type: 'array', items: { type: 'string', maxLength: 500 }, maxItems: 20 }, timeout }, required: ['folder_id', 'package_manager', 'command', 'timeout'], additionalProperties: false } } },
+    { type: 'function', function: { name: 'node_package_script', description: 'Run a package.json script that is explicitly defined in the selected package root, with a timeout and workspace write guard.', parameters: { type: 'object', properties: { folder_id: folderId, path: { type: 'string', description: 'Optional package directory relative to the selected project folder.' }, package_manager: { type: 'string', enum: ['npm', 'pnpm'] }, script: { type: 'string', minLength: 1, maxLength: 100 }, argv: { type: 'array', items: { type: 'string', maxLength: 500 }, maxItems: 20 }, timeout }, required: ['folder_id', 'package_manager', 'script', 'timeout'], additionalProperties: false } } },
     { type: 'function', function: { name: 'python_execute', description: 'Execute an in-memory Python code snippet without allowing file writes.', parameters: { type: 'object', properties: { code: { type: 'string' }, timeout, folder_id: { ...folderId, description: 'Optional project folder to use as the working directory.' } }, required: ['code', 'timeout'], additionalProperties: false } } },
     { type: 'function', function: { name: 'python_run_script', description: 'Run an existing project Python script using the project agent_venv.', parameters: { type: 'object', properties: { ...pathProperties, argv: { type: 'array', items: { type: 'string' }, maxItems: 20 }, timeout }, required: [...pathRequired, 'timeout'], additionalProperties: false } } },
     { type: 'function', function: { name: 'python_install_package', description: 'Install packages into the project agent_venv environment.', parameters: { type: 'object', properties: { packages: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 20 } }, required: ['packages'], additionalProperties: false } } },

--- a/tests/node-sandbox.test.ts
+++ b/tests/node-sandbox.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { runPackageManagerCommand, runPackageScript } from '../src/main/node-sandbox'
+import { createTemporaryDirectory, removeTemporaryDirectory } from './helpers'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(removeTemporaryDirectory))
+})
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await createTemporaryDirectory('codey-node-sandbox-')
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+describe('Node package sandbox', () => {
+  it('runs an explicitly defined package script with arguments', async () => {
+    const root = await temporaryDirectory()
+    await writeFile(join(root, 'package.json'), JSON.stringify({
+      scripts: { echo: 'node script.cjs' },
+    }), 'utf8')
+    await writeFile(join(root, 'script.cjs'), "console.log(process.argv.slice(2).join(','))\n", 'utf8')
+
+    for (const packageManager of ['npm', 'pnpm'] as const) {
+      const result = await runPackageScript(root, packageManager, 'echo', ['one', 'two'], 10)
+
+      expect(result).toEqual(expect.objectContaining({ success: true, exit_code: 0 }))
+      expect(result.stdout).toContain('one,two')
+    }
+  })
+
+  it('rejects scripts that are not defined in package.json', async () => {
+    const root = await temporaryDirectory()
+    await writeFile(join(root, 'package.json'), JSON.stringify({ scripts: {} }), 'utf8')
+
+    await expect(runPackageScript(root, 'pnpm', 'missing', [], 10)).rejects.toThrow(
+      "Script 'missing' is not defined in package.json",
+    )
+  })
+
+  it('prevents Node package scripts from writing outside the package root', async () => {
+    const parent = await temporaryDirectory()
+    const root = join(parent, 'package')
+    await mkdir(root)
+    await writeFile(join(root, 'package.json'), JSON.stringify({
+      scripts: { escape: 'node escape.cjs' },
+    }), 'utf8')
+    await writeFile(
+      join(root, 'escape.cjs'),
+      "console.log(process.env.NODE_OPTIONS); require('node:fs').writeFileSync('../outside.txt', 'unsafe')\n",
+      'utf8',
+    )
+
+    for (const packageManager of ['npm', 'pnpm'] as const) {
+      const result = await runPackageScript(root, packageManager, 'escape', [], 10)
+
+      expect(result.success).toBe(false)
+      expect(result.stderr).toContain('Node sandbox denied access outside the package workspace')
+      await expect(readFile(join(parent, 'outside.txt'), 'utf8')).rejects.toThrow()
+    }
+  })
+
+  it('rejects unsafe package specifiers before invoking a package manager', async () => {
+    const root = await temporaryDirectory()
+
+    await expect(runPackageManagerCommand(root, 'pnpm', 'install', ['../local'], 10)).rejects.toThrow(
+      'valid registry package specifiers',
+    )
+  })
+})
+
+
+
+


### PR DESCRIPTION
Add isolated npm and pnpm package commands with bounded arguments, timeouts, temporary package-manager stores, and output truncation. Allow package scripts only when explicitly defined in package.json and guard Node file access to the package workspace. Add agent tool schemas and coverage for safe package execution.