### PR TITLE
feat(context): initialize Hot and Warm layers from history (#19)

### DIFF
--- a/src/main/agent.ts
+++ b/src/main/agent.ts
@@ -458,30 +458,8 @@ async function requestCompletion(
   throw new Error('Model request failed')
 }
 
-export async function develop(
-  project: Project,
-  config: ModelConfig,
-  contextConfig: ContextManagementConfig,
-  agentLimits: AgentLimitsConfig,
-  agentMessages: AgentContextMessage[],
-  onProgress?: (timeline: DevelopmentTimelineItem[]) => void,
-  onContextSnapshot?: (result: ContextResult) => void,
-  runtime?: { conversationId: string; signal?: AbortSignal; latestUserMessageId?: string },
-): Promise<AgentResult> {
-  if (project.folders.length === 0) {
-    return {
-      writtenFiles: [],
-      agentMessages,
-      timeline: [],
-      summaryArtifacts: [],
-      error: 'Add a project folder before sending a request',
-    }
-  }
-
-  const writtenFiles: string[] = []
-  const tools = createAgentTools(project)
-  const projectDetections = await detectProjectFolders(project.folders)
-  const systemMessage: ContextMessage = {
+function createAgentSystemMessage(project: Project): ContextMessage {
+  return {
     id: randomUUID(),
     createdAt: new Date().toISOString(),
     role: 'system',
@@ -507,6 +485,45 @@ export async function develop(
       'Do not run tests unless the user asks. After completing changes, give a concise summary.',
     ].join('\n'),
   }
+}
+
+export function buildAgentContext(
+  project: Project,
+  config: ModelConfig,
+  contextConfig: ContextManagementConfig,
+  agentMessages: AgentContextMessage[],
+): ContextResult {
+  return manageContext(
+    [createAgentSystemMessage(project), ...toApiMessages(agentMessages)],
+    createAgentTools(project),
+    config,
+    contextConfig,
+  )
+}
+export async function develop(
+  project: Project,
+  config: ModelConfig,
+  contextConfig: ContextManagementConfig,
+  agentLimits: AgentLimitsConfig,
+  agentMessages: AgentContextMessage[],
+  onProgress?: (timeline: DevelopmentTimelineItem[]) => void,
+  onContextSnapshot?: (result: ContextResult) => void,
+  runtime?: { conversationId: string; signal?: AbortSignal; latestUserMessageId?: string },
+): Promise<AgentResult> {
+  if (project.folders.length === 0) {
+    return {
+      writtenFiles: [],
+      agentMessages,
+      timeline: [],
+      summaryArtifacts: [],
+      error: 'Add a project folder before sending a request',
+    }
+  }
+
+  const writtenFiles: string[] = []
+  const tools = createAgentTools(project)
+  const projectDetections = await detectProjectFolders(project.folders)
+  const systemMessage = createAgentSystemMessage(project)
   const history = toApiMessages(agentMessages)
   if (runtime?.latestUserMessageId && !history.some((message) =>
     message.id === runtime.latestUserMessageId && message.role === 'user'

--- a/src/main/context-debug.ts
+++ b/src/main/context-debug.ts
@@ -113,6 +113,26 @@ export function rememberSnapshot(projectId: string, conversationId: string, snap
   snapshotMessages.set(storageKey, currentMessages)
 }
 
+export function hasContextDebugSnapshot(projectId: string, conversationId: string): boolean {
+  return snapshots.has(key(projectId, conversationId))
+}
+
+export function rememberInitializedSnapshot(
+  projectId: string,
+  conversationId: string,
+  snapshot: ContextDebugSnapshot,
+  messages: ContextMessage[],
+): void {
+  rememberSnapshot(projectId, conversationId, snapshot, messages)
+  addAudit(projectId, conversationId, {
+    roundId: snapshot.roundId,
+    requestId: snapshot.requestId,
+    type: 'hot_warm_initialization',
+    messageIds: [...snapshot.hot, ...snapshot.warm].map((item) => item.id),
+    description: 'Initialized Hot and Warm from persisted conversation history',
+    simulated: false,
+  })
+}
 export function getRememberedWarmMessages(projectId: string, conversationId: string): AgentContextMessage[] {
   const storageKey = key(projectId, conversationId)
   const snapshot = snapshots.get(storageKey)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,9 +15,11 @@ import type {
   ImageAttachment,
   ScreenshotSelection,
   ScreenshotSource,
+  Conversation,
+  Project,
 } from '../shared/types'
 import { validateImageAttachments } from '../shared/image-attachments'
-import { develop } from './agent'
+import { buildAgentContext, develop } from './agent'
 import { readConfig, saveConfig } from './config'
 import { resolveContextManagementConfig } from './context-config'
 import {
@@ -26,9 +28,11 @@ import {
   getContextDebugOverview,
   getContextDebugRevision,
   getRememberedWarmMessages,
+  hasContextDebugSnapshot,
   persistContextDebugMessages,
   readColdContextMessage,
   readContextSnapshotMessage,
+  rememberInitializedSnapshot,
   rememberSnapshot,
   searchColdContext,
   setContextPin,
@@ -411,11 +415,45 @@ async function selectScreenshotArea(
   })
 }
 
+async function initializeContextDebugContext(
+  projectId: string,
+  conversationId: string,
+  project: Project,
+  conversation: Conversation,
+  appConfig: AppConfig,
+): Promise<void> {
+  if (getConversationState(projectId, conversationId) !== 'idle') return
+  if (hasContextDebugSnapshot(projectId, conversationId)) return
+
+  const modelConfig = resolveModelConfig(appConfig, project, conversation)
+  if (!modelConfig) return
+  const contextConfig = structuredClone(
+    resolveContextManagementConfig(appConfig, project, conversation),
+  )
+  const history = contextConfig.layeredEnabled
+    ? await readConversationWorkingSet(
+        projectId,
+        conversationId,
+        contextConfig,
+        '',
+        getRememberedWarmMessages(projectId, conversationId),
+      )
+    : await readConversationMessages(projectId, conversationId)
+  const managed = buildAgentContext(project, modelConfig, contextConfig, history)
+  const snapshot = buildContextDebugSnapshot(managed, contextConfig, randomUUID(), randomUUID())
+  rememberInitializedSnapshot(
+    projectId,
+    conversationId,
+    snapshot,
+    [...managed.messages, ...managed.warmMessages],
+  )
+}
 async function openContextDebugWindow(projectId: string, conversationId: string): Promise<void> {
   const config = await readConfig()
   if (!config.developerMode) throw new Error('Developer mode is disabled')
   const project = await getProject(projectId)
-  if (!project.conversations.some((item) => item.id === conversationId)) {
+  const conversation = project.conversations.find((item) => item.id === conversationId)
+  if (!conversation) {
     throw new Error('Conversation not found')
   }
   await prepareContextDebugStorage(projectId, conversationId)
@@ -426,6 +464,7 @@ async function openContextDebugWindow(projectId: string, conversationId: string)
     existing.focus()
     return
   }
+  await initializeContextDebugContext(projectId, conversationId, project, conversation, config)
   const window = new BrowserWindow({
     width: 1320,
     height: 850,

--- a/src/renderer/src/i18n.ts
+++ b/src/renderer/src/i18n.ts
@@ -234,6 +234,7 @@ void i18n.use(initReactI18next).init({
         audit_manual_demotion: 'Manual demotion',
         audit_pinned_ratio_warning: 'Pinned ratio warning',
         audit_token_simulation: 'Token simulation',
+        audit_hot_warm_initialization: 'Hot / Warm initialization',
       },
     },
     'zh-CN': {
@@ -451,6 +452,7 @@ void i18n.use(initReactI18next).init({
         audit_manual_demotion: '手动下沉',
         audit_pinned_ratio_warning: '固定内容占比告警',
         audit_token_simulation: 'Token 模拟',
+        audit_hot_warm_initialization: 'Hot / Warm 初始化',
       },
     },
   },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -314,6 +314,7 @@ export type ContextAuditEvent = {
     | 'manual_demotion'
     | 'pinned_ratio_warning'
     | 'token_simulation'
+    | 'hot_warm_initialization'
   messageIds: string[]
   tokenDelta?: number
   description: string


### PR DESCRIPTION
Initialize the context debugger's Hot/Warm snapshot from persisted conversation history when an idle conversation is opened for the first time, reusing the existing working-set and context-building logic without adding a user message or writing summaries. Add a localized initialization audit event.