### PR TITLE
feat(context): track layered transitions and conversation rounds (#42)

### DIFF
--- a/src/main/agent.ts
+++ b/src/main/agent.ts
@@ -572,14 +572,19 @@ export function buildAgentContext(
   contextConfig: ContextManagementConfig,
   agentMessages: AgentContextMessage[],
   networkAccessEnabled = false,
-  customStrategy?: { allow: boolean; latestUserMessageId?: string },
+  customStrategy?: { allow: boolean; latestUserMessageId?: string; roundId?: string; roundCount?: number },
 ): ContextResult {
   return manageContext(
     [createAgentSystemMessage(project, networkAccessEnabled), ...toApiMessages(agentMessages)],
     createAgentTools(project, networkAccessEnabled),
     config,
     contextConfig,
-    { allowCustomStrategy: customStrategy?.allow, latestUserMessageId: customStrategy?.latestUserMessageId },
+    {
+      allowCustomStrategy: customStrategy?.allow,
+      latestUserMessageId: customStrategy?.latestUserMessageId,
+      roundId: customStrategy?.roundId,
+      roundCount: customStrategy?.roundCount,
+    },
   )
 }
 export async function develop(
@@ -590,7 +595,16 @@ export async function develop(
   agentMessages: AgentContextMessage[],
   onProgress?: (update: DevelopmentProgressUpdate) => void,
   onContextSnapshot?: (result: ContextResult) => void,
-  runtime?: { conversationId: string; projectId?: string; traceId?: string; signal?: AbortSignal; latestUserMessageId?: string; allowCustomStrategy?: boolean },
+  runtime?: {
+    conversationId: string
+    projectId?: string
+    traceId?: string
+    signal?: AbortSignal
+    latestUserMessageId?: string
+    allowCustomStrategy?: boolean
+    roundId?: string
+    roundCount?: number
+  },
   networkAccessEnabled = false,
 ): Promise<AgentResult> {
   if (project.folders.length === 0) {
@@ -634,12 +648,20 @@ export async function develop(
       const managed = manageContext([systemMessage, ...activeHistory], tools, config, contextConfig, {
         allowCustomStrategy: runtime?.allowCustomStrategy,
         latestUserMessageId: runtime?.latestUserMessageId,
+        roundId: runtime?.roundId,
+        roundCount: runtime?.roundCount,
       })
       recordPerformanceTrace({
         traceId: runtime?.traceId ?? 'unknown', scope: 'agent', phase: 'context-manage',
         projectId: runtime?.projectId, conversationId: runtime?.conversationId,
         durationMs: performance.now() - contextManageStartedAt,
-        data: { requestIndex, inputMessages: activeHistory.length + 1, outputMessages: managed.messages.length, outputTokens: managed.metrics.compressedTokens },
+        data: {
+          requestIndex,
+          roundCount: runtime?.roundCount ?? 0,
+          inputMessages: activeHistory.length + 1,
+          outputMessages: managed.messages.length,
+          outputTokens: managed.metrics.compressedTokens,
+        },
       })
       if ((!runtime?.allowCustomStrategy || !contextConfig.customStrategyEnabled || !contextConfig.customStrategyScript?.trim()) &&
         runtime?.latestUserMessageId && !managed.messages.some((message) =>

--- a/src/main/context-debug.ts
+++ b/src/main/context-debug.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import type {
   AgentContextMessage,
+  ContextAction,
   ContextAuditEvent,
   ContextDebugMessage,
   ContextDebugOverview,
@@ -75,7 +76,38 @@ function addAudit(projectId: string, conversationId: string, event: Omit<Context
   audits.set(storageKey, list.slice(-300))
 }
 
-export function buildContextDebugSnapshot(result: ContextResult, config: import('../shared/types').ContextManagementConfig, requestId = randomUUID(), roundId = requestId): ContextDebugSnapshot {
+function addAutomaticActionAudit(
+  projectId: string,
+  conversationId: string,
+  snapshot: ContextDebugSnapshot,
+  type: ContextAuditEvent['type'],
+  action: ContextAction,
+  description: string,
+): void {
+  const storageKey = key(projectId, conversationId)
+  const messageIds = [...new Set(action.messageIds)].sort()
+  const list = audits.get(storageKey) ?? []
+  const alreadyRecorded = list.some((event) =>
+    event.roundId === snapshot.roundId
+      && event.type === type
+      && event.messageIds.length === messageIds.length
+      && [...event.messageIds].sort().every((id, index) => id === messageIds[index])
+  )
+  if (alreadyRecorded) return
+  addAudit(projectId, conversationId, {
+    roundId: snapshot.roundId,
+    roundCount: snapshot.roundCount,
+    requestId: snapshot.requestId,
+    type,
+    messageIds: action.messageIds,
+    truthRefs: action.truthRefs,
+    tokenDelta: action.tokenDelta,
+    description,
+    simulated: false,
+  })
+}
+
+export function buildContextDebugSnapshot(result: ContextResult, config: import('../shared/types').ContextManagementConfig, requestId = randomUUID(), roundId = requestId, roundCount = 0): ContextDebugSnapshot {
   const system = result.messages.filter((message) => message.role === 'system')
   const hot = result.messages.filter((message) => message.role !== 'system')
   const hotItems = [...system.map((message) => toItem(message, 'system')), ...hot.map((message) => toItem(message, sourceOf(message)))]
@@ -84,6 +116,7 @@ export function buildContextDebugSnapshot(result: ContextResult, config: import(
   return {
     requestId,
     roundId,
+    roundCount,
     createdAt: new Date().toISOString(),
     modelMaxContext: result.metrics.modelMaxContext,
     triggerThreshold: result.metrics.triggerThreshold,
@@ -103,19 +136,43 @@ export function buildContextDebugSnapshot(result: ContextResult, config: import(
   }
 }
 
-export function rememberSnapshot(projectId: string, conversationId: string, snapshot: ContextDebugSnapshot, messages: ContextMessage[], summaries: ContextSummaryArtifact[] = []): void {
+export function rememberSnapshot(
+  projectId: string,
+  conversationId: string,
+  snapshot: ContextDebugSnapshot,
+  messages: ContextMessage[],
+  summaries: ContextSummaryArtifact[] = [],
+  actions: ContextAction[] = [],
+): void {
   const storageKey = key(projectId, conversationId)
-  const previous = snapshots.get(storageKey)
-  if (previous) {
-    const previousHot = new Set(previous.hot.map((item) => item.id))
-    const currentHot = new Set(snapshot.hot.map((item) => item.id))
-    const demoted = previous.hot.filter((item) => !currentHot.has(item.id) && item.source !== 'system').map((item) => item.id)
-    if (demoted.length > 0) addAudit(projectId, conversationId, { roundId: snapshot.roundId, requestId: snapshot.requestId, type: 'hot_to_warm', messageIds: demoted, description: `${demoted.length} message(s) moved from Hot to Warm`, simulated: false })
+  const auditAction = (action: ContextAction): void => {
+    const type = action.type === 'demote' ? 'hot_to_warm'
+      : action.type === 'summarize' ? 'warm_to_cold'
+        : action.type === 'promote' ? 'warm_to_hot' : 'cold_recall'
+    const description = action.type === 'demote'
+      ? `${action.messageIds.length} message(s) moved from Hot to Warm`
+      : action.type === 'summarize'
+        ? `${action.messageIds.length} Warm message(s) summarized for Cold storage`
+        : action.type === 'promote'
+          ? `${action.messageIds.length} message(s) promoted from Warm to Hot`
+          : `${action.messageIds.length} context record(s) recalled into Warm`
+    addAutomaticActionAudit(projectId, conversationId, snapshot, type, action, description)
   }
-  const recalled = snapshot.hot.filter((item) => item.source === 'cold-truth-recall' || item.source === 'cold-summary-recall').map((item) => item.id)
-  if (recalled.length > 0) addAudit(projectId, conversationId, { roundId: snapshot.roundId, requestId: snapshot.requestId, type: 'cold_recall', messageIds: recalled, description: `${recalled.length} Cold record(s) promoted into Hot Newborn`, simulated: false })
-  if (summaries.length > 0) addAudit(projectId, conversationId, { roundId: snapshot.roundId, requestId: snapshot.requestId, type: 'warm_to_cold', messageIds: summaries.flatMap((summary) => summary.sourceMessageIds), tokenDelta: summaries.reduce((sum, summary) => sum + summary.originalTokens - summary.compressedTokens, 0), description: `${summaries.length} Warm message(s) summarized for Cold storage`, simulated: false })
-  if (snapshot.hotTokens > 0 && snapshot.pinnedHotTokens / snapshot.hotTokens >= 0.8) addAudit(projectId, conversationId, { roundId: snapshot.roundId, requestId: snapshot.requestId, type: 'pinned_ratio_warning', messageIds: snapshot.hot.filter((item) => item.pinnedToHot).map((item) => item.id), description: 'Pinned Hot messages occupy at least 80% of Hot tokens', simulated: false })
+
+  const previous = snapshots.get(storageKey)
+  if (actions.length > 0) {
+    actions.forEach(auditAction)
+  } else {
+    if (previous) {
+      const currentHot = new Set(snapshot.hot.map((item) => item.id))
+      const demoted = previous.hot.filter((item) => !currentHot.has(item.id) && item.source !== 'system').map((item) => item.id)
+      if (demoted.length > 0) addAudit(projectId, conversationId, { roundId: snapshot.roundId, roundCount: snapshot.roundCount, requestId: snapshot.requestId, type: 'hot_to_warm', messageIds: demoted, description: `${demoted.length} message(s) moved from Hot to Warm`, simulated: false })
+    }
+    const recalled = snapshot.hot.filter((item) => item.source === 'cold-truth-recall' || item.source === 'cold-summary-recall').map((item) => item.id)
+    if (recalled.length > 0) addAudit(projectId, conversationId, { roundId: snapshot.roundId, roundCount: snapshot.roundCount, requestId: snapshot.requestId, type: 'cold_recall', messageIds: recalled, description: `${recalled.length} Cold record(s) promoted into Hot Newborn`, simulated: false })
+    if (summaries.length > 0) addAudit(projectId, conversationId, { roundId: snapshot.roundId, roundCount: snapshot.roundCount, requestId: snapshot.requestId, type: 'warm_to_cold', messageIds: summaries.flatMap((summary) => summary.sourceMessageIds), tokenDelta: summaries.reduce((sum, summary) => sum + summary.originalTokens - summary.compressedTokens, 0), description: `${summaries.length} Warm message(s) summarized for Cold storage`, simulated: false })
+  }
+  if (snapshot.hotTokens > 0 && snapshot.pinnedHotTokens / snapshot.hotTokens >= 0.8) addAudit(projectId, conversationId, { roundId: snapshot.roundId, roundCount: snapshot.roundCount, requestId: snapshot.requestId, type: 'pinned_ratio_warning', messageIds: snapshot.hot.filter((item) => item.pinnedToHot).map((item) => item.id), description: 'Pinned Hot messages occupy at least 80% of Hot tokens', simulated: false })
   const promoted = promotedHotIds.get(storageKey)
   if (promoted) {
     const currentHot = new Set(snapshot.hot.map((item) => item.id))
@@ -141,10 +198,12 @@ export function rememberInitializedSnapshot(
   conversationId: string,
   snapshot: ContextDebugSnapshot,
   messages: ContextMessage[],
+  actions: ContextAction[] = [],
 ): void {
-  rememberSnapshot(projectId, conversationId, snapshot, messages)
+  rememberSnapshot(projectId, conversationId, snapshot, messages, [], actions)
   addAudit(projectId, conversationId, {
     roundId: snapshot.roundId,
+    roundCount: snapshot.roundCount,
     requestId: snapshot.requestId,
     type: 'hot_warm_initialization',
     messageIds: [...snapshot.hot, ...snapshot.warm].map((item) => item.id),

--- a/src/main/context-utils.ts
+++ b/src/main/context-utils.ts
@@ -36,9 +36,26 @@ function messageMetadataSignature(message: ContextMessage): string {
   ].join('\u0001')
 }
 
+function isContextMessage(value: unknown): value is { role: string; content: unknown; images?: unknown; tool_calls?: unknown; tool_call_id?: unknown } {
+  return Boolean(value && typeof value === 'object' && 'role' in value && 'content' in value)
+}
+
+function modelFacingValue(value: unknown): unknown {
+  if (isContextMessage(value)) {
+    return {
+      role: value.role,
+      content: value.content,
+      images: value.images,
+      tool_calls: value.tool_calls,
+      tool_call_id: value.tool_call_id,
+    }
+  }
+  if (Array.isArray(value) && value.every(isContextMessage)) return value.map(modelFacingValue)
+  return value
+}
 export function countContextTokens(value: unknown): number {
   let imageCount = 0
-  const serialized = JSON.stringify(value, (_key, item: unknown) => {
+  const serialized = JSON.stringify(modelFacingValue(value), (_key, item: unknown) => {
     if (
       item && typeof item === 'object' &&
       'dataUrl' in item && 'mediaType' in item &&

--- a/src/main/context.ts
+++ b/src/main/context.ts
@@ -1,5 +1,5 @@
 import type { ImageAttachment } from '../shared/image-attachments'
-import type { ContextManagementConfig, ContextMetrics, ContextRepresentation, ContextSummaryArtifact, ModelConfig } from '../shared/types'
+import type { ContextAction, ContextManagementConfig, ContextMetrics, ContextRepresentation, ContextSummaryArtifact, ModelConfig } from '../shared/types'
 import type { ToolCall } from './tools'
 import { countContextMessageTokens, countContextTokens, createContextTokenCounter, normalizeToolCallSequence } from './context-utils'
 import { applyCustomRhaiStrategy } from './rhai-strategy'
@@ -37,6 +37,7 @@ export type ContextResult = {
   /** Warm is diagnostic working memory and is never sent directly. */
   warmMessages: ContextMessage[]
   summaryArtifacts: ContextSummaryArtifact[]
+  actions: ContextAction[]
   metrics: ContextMetrics
   toolDefinitionTokens: number
   hotTokenBudget?: number
@@ -256,7 +257,8 @@ function metrics(originalTokens: number, compressedTokens: number, modelConfig: 
 }
 
 function manageSingleLayer(messages: ContextMessage[], tools: object[], modelConfig: ModelConfig, contextConfig: ContextManagementConfig): ContextResult {
-  const triggerThreshold = Math.max(1, modelConfig.modelMaxContext - contextConfig.safeOutputMargin)
+  const effectiveOutputMargin = contextConfig.safeOutputMargin >= modelConfig.modelMaxContext ? 0 : Math.max(0, contextConfig.safeOutputMargin)
+  const triggerThreshold = Math.max(1, modelConfig.modelMaxContext - effectiveOutputMargin)
   const counter = createContextTokenCounter(tools)
   const originalTokens = counter.request(messages)
   let managed = messages
@@ -307,23 +309,32 @@ function manageSingleLayer(messages: ContextMessage[], tools: object[], modelCon
     messages: sendable,
     warmMessages: [],
     summaryArtifacts: [],
+    actions: [],
     metrics: metrics(originalTokens, compressedTokens, modelConfig, contextConfig, { layered: false, recalled: false, filtered, rewritten, truncated }),
     toolDefinitionTokens: counter.toolDefinitionTokens,
   }
 }
 
 function manageLayered(messages: ContextMessage[], tools: object[], modelConfig: ModelConfig, contextConfig: ContextManagementConfig, runtime: ContextManagementRuntime): ContextResult {
-  const triggerThreshold = Math.max(1, modelConfig.modelMaxContext - contextConfig.safeOutputMargin)
+  const effectiveOutputMargin = contextConfig.safeOutputMargin >= modelConfig.modelMaxContext ? 0 : Math.max(0, contextConfig.safeOutputMargin)
+  const triggerThreshold = Math.max(1, modelConfig.modelMaxContext - effectiveOutputMargin)
   const counter = createContextTokenCounter(tools)
   const toolDefinitionTokens = counter.toolDefinitionTokens
   const hotBudget = Math.max(1, Math.min(contextConfig.hotTokenBudget, triggerThreshold - toolDefinitionTokens))
   const highWatermark = Math.max(1, Math.floor(hotBudget * 0.9))
   const lowWatermark = Math.max(1, Math.floor(hotBudget * 0.8))
-  const requestCount = (items: ContextMessage[]) => counter.request(items)
-  const layerCount = (items: ContextMessage[]) => counter.layer(items)
   const messageCount = (items: ContextMessage[]) => counter.messages(items)
-  const originalTokens = requestCount(messages)
+  const originalTokens = counter.request(messages)
   const now = new Date().toISOString()
+  const actions: ContextAction[] = []
+  const addAction = (type: ContextAction['type'], items: ContextMessage[], tokenDelta?: number): void => {
+    const messageIds = [...new Set(items.flatMap((message) => message.id ? [message.id] : []))]
+    if (messageIds.length === 0) return
+    const truthRefs = [...new Set(items.flatMap(refsFor))]
+    const signature = `${type}:${messageIds.join('|')}`
+    if (actions.some((action) => `${action.type}:${action.messageIds.join('|')}` === signature)) return
+    actions.push({ type, messageIds, truthRefs, ...(tokenDelta === undefined ? {} : { tokenDelta }) })
+  }
   const system = messages.filter((message) => message.role === 'system').map((message) => ({
     ...message,
     contextLayer: 'hot' as const,
@@ -339,12 +350,10 @@ function manageLayered(messages: ContextMessage[], tools: object[], modelConfig:
   let currentStart = runtime.latestUserMessageId
     ? eligible.findIndex((message) => message.id === runtime.latestUserMessageId && message.role === 'user')
     : -1
-  if (currentStart < 0) {
-    currentStart = eligible.reduce((found, message, index) => message.role === 'user' ? index : found, 0)
-  }
+  if (currentStart < 0) currentStart = eligible.reduce((found, message, index) => message.role === 'user' ? index : found, 0)
   const historical = eligible.slice(0, currentStart)
   const current = eligible.slice(currentStart)
-  const warmCandidates = [...explicitWarm]
+  const warmCandidates: ContextMessage[] = [...explicitWarm]
   const toHot = (message: ContextMessage, fresh = false): ContextMessage => ({
     ...message,
     contextLayer: 'hot',
@@ -354,6 +363,14 @@ function manageLayered(messages: ContextMessage[], tools: object[], modelConfig:
     truthRefs: refsFor(message),
     enteredHotAt: fresh ? now : message.enteredHotAt ?? message.createdAt ?? now,
     reuseCount: Math.max(0, message.reuseCount ?? 0),
+  })
+  const toWarm = (message: ContextMessage): ContextMessage => ({
+    ...message,
+    contextLayer: 'warm',
+    contextRegion: message.contextRegion ?? 'newborn',
+    contextSource: isRecalled(message) ? message.contextSource : 'hot-demotion',
+    representation: message.representation ?? 'original',
+    truthRefs: refsFor(message),
   })
   const historicalHot = historical.map((message) => toHot(message))
   const currentHot = current.map((message) => toHot(message))
@@ -365,46 +382,44 @@ function manageLayered(messages: ContextMessage[], tools: object[], modelConfig:
   const replacementSet = replaceableIds([...historicalHot, ...recalled, ...currentHot])
   const demote = (items: ContextMessage[]): void => {
     const selected = new Set(items)
+    const selectedHot = hot.filter((message) => selected.has(message))
+    if (selectedHot.length === 0) return
     hot = hot.filter((message) => !selected.has(message))
-    hotMessageTokens -= messageCount(items)
-    warmCandidates.push(...items)
+    hotMessageTokens -= messageCount(selectedHot)
+    warmCandidates.push(...selectedHot.map(toWarm))
+    addAction('demote', selectedHot, -messageCount(selectedHot))
   }
   const historicalCandidates = splitRounds(historicalHot)
-    .map((round) => splitClosedUnits(round).units
-      .filter((unit) => unit.every((message) => !isResident(message)))
-      .flat())
-    .filter((round) => round.length > 0)
-    .map((round) => ({
-      messages: round,
-      score: Math.max(...round.map((message) => contextImportanceScore(message, Boolean(message.id && replacementSet.has(message.id))))),
-      lastAccessedAt: Math.max(...round.map((message) => timestamp(message.lastAccessedAt))),
-      enteredHotAt: Math.max(...round.map((message) => timestamp(message.enteredHotAt ?? message.createdAt))),
-      tokens: messageCount(round),
-    }))
-    .sort((left, right) => left.score - right.score || left.lastAccessedAt - right.lastAccessedAt || left.enteredHotAt - right.enteredHotAt || right.tokens - left.tokens)
-
-  if (hotTokens() >= highWatermark) {
-    for (const candidate of historicalCandidates) {
-      if (hotTokens() <= lowWatermark) break
-      demote(candidate.messages)
-    }
-  }
-
-  for (const message of recalled) {
-    const promoted = toHot(message, !message.enteredHotAt)
-    const insertAt = Math.max(0, hot.length - currentHot.filter((item) => hot.includes(item)).length)
-    hot.splice(insertAt, 0, promoted)
-    hotMessageTokens += counter.message(promoted)
-    if (hotTokens() > highWatermark || !fitsHardLimit()) {
-      hot.splice(hot.indexOf(promoted), 1)
-      hotMessageTokens -= counter.message(promoted)
-      if (message.contextSource === 'warm-recall') warmCandidates.push({ ...message, contextLayer: 'warm', contextSource: 'hot-demotion' })
-    }
-  }
+    .flatMap((round) => {
+      const { units, hasOpenTail } = splitClosedUnits(round)
+      const hasResident = units.some((unit) => unit.some(isResident))
+      const candidates = !hasResident && !hasOpenTail
+        ? [round]
+        : units.filter((unit) => unit.every((message) => !isResident(message)))
+      return candidates.map((unit) => ({
+        messages: unit,
+        score: Math.max(...unit.map((message) => contextImportanceScore(message, Boolean(message.id && replacementSet.has(message.id))))),
+        lastAccessedAt: Math.max(...unit.map((message) => timestamp(message.lastAccessedAt))),
+        enteredHotAt: Math.max(...unit.map((message) => timestamp(message.enteredHotAt ?? message.createdAt))),
+        tokens: messageCount(unit),
+      }))
+    })
+    .sort((left, right) => left.enteredHotAt - right.enteredHotAt || left.score - right.score || left.lastAccessedAt - right.lastAccessedAt || right.tokens - left.tokens)
 
   const latestUser = runtime.latestUserMessageId
-    ? hot.find((message) => message.id === runtime.latestUserMessageId && message.role === 'user')
+    ? currentHot.find((message) => message.id === runtime.latestUserMessageId && message.role === 'user')
     : currentHot.find((message) => message.role === 'user')
+  const currentTailStart = latestUser ? Math.max(0, currentHot.findIndex((message) => message.id === latestUser.id) + 1) : currentHot.length
+  const currentCandidates = splitClosedUnits(currentHot.slice(currentTailStart)).units
+    .filter((unit) => unit.every((message) => !isResident(message)))
+    .map((unit) => ({
+      messages: unit,
+      score: Math.max(...unit.map((message) => contextImportanceScore(message, Boolean(message.id && replacementSet.has(message.id))))),
+      lastAccessedAt: Math.max(...unit.map((message) => timestamp(message.lastAccessedAt))),
+      enteredHotAt: Math.max(...unit.map((message) => timestamp(message.enteredHotAt ?? message.createdAt))),
+      tokens: messageCount(unit),
+    }))
+    .sort((left, right) => left.enteredHotAt - right.enteredHotAt || left.score - right.score || left.lastAccessedAt - right.lastAccessedAt || right.tokens - left.tokens)
   const latestOnlyMessageTokens = messageCount(system) + (latestUser ? counter.message(latestUser) : 0)
   const latestOnlyLayerTokens = counter.layerBaseTokens + latestOnlyMessageTokens
   const latestOnlyRequestTokens = counter.requestBaseTokens + latestOnlyMessageTokens
@@ -416,17 +431,53 @@ function manageLayered(messages: ContextMessage[], tools: object[], modelConfig:
     }
   }
 
-  if (!overflow && !fitsHardLimit()) {
-    const currentInHot = currentHot.filter((message) => hot.includes(message))
-    const { units, hasOpenTail } = splitClosedUnits(currentInHot.slice(1))
-    const demotableUnits = (hasOpenTail ? units : units.slice(0, -1))
-      .filter((unit) => unit.every((message) => !isResident(message)))
-    for (const unit of demotableUnits) {
-      if (hotTokens() <= highWatermark && fitsHardLimit()) break
-      demote(unit)
+  let candidateIndex = 0
+  let currentCandidateIndex = 0
+  const releaseHistoricalHot = (reachLowWatermark: boolean): void => {
+    while (!overflow && candidateIndex < historicalCandidates.length && (!fitsHardLimit() || hotTokens() >= highWatermark)) {
+      if (reachLowWatermark && hotTokens() <= lowWatermark && fitsHardLimit()) break
+      demote(historicalCandidates[candidateIndex].messages)
+      candidateIndex += 1
+    }
+  }
+  const releaseCurrentHot = (): void => {
+    while (!overflow && !fitsHardLimit() && currentCandidateIndex < currentCandidates.length) {
+      demote(currentCandidates[currentCandidateIndex].messages)
+      currentCandidateIndex += 1
+    }
+  }
+  releaseHistoricalHot(true)
+  if (!overflow && !fitsHardLimit()) releaseCurrentHot()
+
+  for (const message of recalled) {
+    addAction('recall', [message], counter.message(message))
+    const promoted = toHot(message, true)
+    const insertAt = Math.max(0, hot.length - currentHot.filter((item) => hot.includes(item)).length)
+    hot.splice(insertAt, 0, promoted)
+    hotMessageTokens += counter.message(promoted)
+    if (!overflow && hotTokens() <= highWatermark && fitsHardLimit()) {
+      addAction('promote', [promoted], counter.message(promoted))
+      continue
+    }
+    hot.splice(hot.indexOf(promoted), 1)
+    hotMessageTokens -= counter.message(promoted)
+    warmCandidates.push(toWarm(message))
+    releaseHistoricalHot(false)
+    if (!overflow && !fitsHardLimit()) releaseCurrentHot()
+    if (!overflow && hotTokens() <= highWatermark && fitsHardLimit()) {
+      const retry = toHot(message, true)
+      hot.splice(Math.max(0, hot.length - currentHot.filter((item) => hot.includes(item)).length), 0, retry)
+      hotMessageTokens += counter.message(retry)
+      if (hotTokens() <= highWatermark && fitsHardLimit()) addAction('promote', [retry], counter.message(retry))
+      else {
+        hot.splice(hot.indexOf(retry), 1)
+        hotMessageTokens -= counter.message(retry)
+      }
     }
   }
 
+  if (!overflow && !fitsHardLimit()) releaseHistoricalHot(false)
+  if (!overflow && !fitsHardLimit()) releaseCurrentHot()
   if (!overflow && !fitsHardLimit()) {
     const pinnedBlockers = hot.some((message) => message.pinnedToHot === true)
     overflow = {
@@ -438,29 +489,22 @@ function manageLayered(messages: ContextMessage[], tools: object[], modelConfig:
   const managed = normalizeToolCallSequence([...system, ...hot])
   let filtered = false
   let rewritten = false
+  let warmTokens = 0
   const warmMessages: ContextMessage[] = []
   const summaryArtifacts: ContextSummaryArtifact[] = []
-  let warmTokens = 0
   const warmById = new Map<string, ContextMessage>()
   for (const message of warmCandidates) warmById.set(message.id ?? `${message.role}:${message.createdAt ?? ''}:${warmById.size}`, message)
-  const orderedWarm = [...warmById.values()].sort((left, right) => messages.indexOf(left) - messages.indexOf(right))
+  const orderedWarm = [...warmById.values()].sort((left, right) => messages.findIndex((message) => message.id === left.id) - messages.findIndex((message) => message.id === right.id))
   for (let index = orderedWarm.length - 1; index >= 0; index -= 1) {
     const original = orderedWarm[index]
-    const prepared: ContextMessage = {
-      ...original,
-      contextLayer: 'warm',
-      contextRegion: original.contextRegion ?? 'newborn',
-      contextSource: original.contextSource === 'cold-summary-recall' ? 'cold-summary-recall' : 'hot-demotion',
-      representation: original.representation ?? 'original',
-      truthRefs: refsFor(original),
-    }
+    const prepared = toWarm(original)
     const tokenCount = counter.message(prepared)
     if (warmTokens + tokenCount <= contextConfig.warmTokenBudget) {
       warmMessages.unshift(prepared)
       warmTokens += tokenCount
       continue
     }
-
+    if (original.representation === 'summary') continue
     let transformed = original
     const methods: string[] = []
     if (contextConfig.filterEnabled) {
@@ -480,7 +524,14 @@ function manageLayered(messages: ContextMessage[], tools: object[], modelConfig:
       transformed = next
     }
     const fallback = `A ${original.role} message was removed from Warm memory. Read the referenced Cold truth record for its exact content.`
-    summaryArtifacts.unshift(buildSummaryArtifact(original, transformed.content !== original.content ? transformed.content ?? fallback : fallback, methods.join('/') || 'locator'))
+    const artifact = buildSummaryArtifact(original, transformed.content !== original.content ? transformed.content ?? fallback : fallback, methods.join('/') || 'locator')
+    if (!summaryArtifacts.some((summary) => summary.id === artifact.id)) summaryArtifacts.unshift(artifact)
+    const summary = summaryMessage({ ...original, id: artifact.id, createdAt: artifact.createdAt }, artifact.content)
+    if (warmTokens + counter.message(summary) <= contextConfig.warmTokenBudget) {
+      warmMessages.unshift(summary)
+      warmTokens += counter.message(summary)
+    }
+    addAction('summarize', [original], artifact.originalTokens - artifact.compressedTokens)
   }
 
   const compressedTokens = counter.request(managed)
@@ -488,9 +539,10 @@ function manageLayered(messages: ContextMessage[], tools: object[], modelConfig:
     messages: managed,
     warmMessages,
     summaryArtifacts,
+    actions,
     metrics: metrics(originalTokens, compressedTokens, modelConfig, contextConfig, {
       layered: true,
-      recalled: hot.some((message) => ['cold-summary-recall', 'cold-truth-recall', 'cold-recall', 'warm-recall'].includes(message.contextSource ?? '')),
+      recalled: recalled.length > 0 || hot.some((message) => isRecalled(message)),
       filtered,
       rewritten,
       truncated: false,
@@ -505,6 +557,8 @@ function manageLayered(messages: ContextMessage[], tools: object[], modelConfig:
 export type ContextManagementRuntime = {
   allowCustomStrategy?: boolean
   latestUserMessageId?: string
+  roundId?: string
+  roundCount?: number
 }
 
 export function manageContext(
@@ -528,6 +582,7 @@ export function manageContext(
       })),
       warmMessages: [],
       summaryArtifacts: [],
+      actions: [],
       metrics: metrics(originalTokens, compressedTokens, modelConfig, contextConfig, {
         layered: contextConfig.layeredEnabled,
         recalled: customMessages.some((message) => ['warm-recall', 'cold-summary-recall', 'cold-truth-recall', 'cold-recall'].includes(message.contextSource ?? '')),

--- a/src/main/conversation-store.ts
+++ b/src/main/conversation-store.ts
@@ -472,6 +472,7 @@ export async function readConversationWorkingSet(
   rememberedHot: AgentContextMessage[] = [],
   latestUserMessageId?: string,
   latestUserMessage?: AgentContextMessage,
+  currentRoundId?: string,
 ): Promise<AgentContextMessage[]> {
   const index = await readConversationIndex(projectId, conversationId)
   const indexById = new Map(index.map((item) => [item.id, item]))
@@ -497,7 +498,7 @@ export async function readConversationWorkingSet(
     ...message,
     contextLayer: 'warm',
     contextRegion: message.contextRegion ?? 'newborn',
-    contextSource: message.contextSource === 'cold-summary-recall' ? 'cold-summary-recall' : 'hot-demotion',
+    contextSource: message.contextSource ?? 'hot-demotion',
     representation: message.representation ?? 'original',
     truthRefs: message.truthRefs?.length ? message.truthRefs : message.id ? [message.id] : [],
   })
@@ -568,13 +569,13 @@ export async function readConversationWorkingSet(
   for (const { message } of warmMatches) {
     const tokenCount = countContextMessageTokens(message)
     if (recalledTokens + tokenCount > config.coldRecallTokenBudget) continue
-    recalled.push(asHot({
+    recalled.push(asWarm({
       ...message,
       contextSource: 'warm-recall',
+      recalledAtRoundId: currentRoundId,
       lastAccessedAt: now,
       reuseCount: (message.reuseCount ?? 0) + 1,
-    }, true))
-    warmById.delete(message.id ?? '')
+    }))
     for (const truthRef of message.truthRefs ?? []) recalledTruthRefs.add(truthRef)
     recalledTokens += tokenCount
   }
@@ -584,7 +585,7 @@ export async function readConversationWorkingSet(
     if (residentIds.has(match.id) || warmById.has(match.id) || match.truthRefs.some((id) => recalledTruthRefs.has(id)) || recalledTokens + match.tokenCount > config.coldRecallTokenBudget) continue
     const [message] = await readContextRecords(projectId, conversationId, [match.id])
     if (!message) continue
-    recalled.push(message)
+    recalled.push(asWarm({ ...message, recalledAtRoundId: currentRoundId }))
     for (const truthRef of message.truthRefs ?? []) recalledTruthRefs.add(truthRef)
     recalledTokens += match.tokenCount
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -330,6 +330,7 @@ async function developProject(
   // context-store write needs to delay the first model request.
 
   const roundId = randomUUID()
+  const roundCount = conversation.agentMessages.filter((message) => message.role === 'user').length + 1
   const contextReadStartedAt = performance.now()
   const requestHistory = contextConfig.layeredEnabled
     ? await readConversationWorkingSet(
@@ -342,6 +343,7 @@ async function developProject(
         conversation.agentMessages.filter((message) => message.contextLayer !== 'warm'),
         userMessageId,
         currentUserMessage,
+        roundId,
       )
     : await readConversationMessages(projectId, conversationId, [...conversation.agentMessages, currentUserMessage])
   recordPerformanceTrace({
@@ -365,8 +367,8 @@ async function developProject(
     requestHistory,
     onProgress,
     (managed) => {
-      const snapshot = buildContextDebugSnapshot(managed, contextConfig, randomUUID(), roundId)
-      rememberSnapshot(projectId, conversationId, snapshot, [...managed.messages, ...managed.warmMessages], managed.summaryArtifacts)
+      const snapshot = buildContextDebugSnapshot(managed, contextConfig, randomUUID(), roundId, roundCount)
+      rememberSnapshot(projectId, conversationId, snapshot, [...managed.messages, ...managed.warmMessages], managed.summaryArtifacts, managed.actions)
     },
     {
       conversationId,
@@ -375,6 +377,8 @@ async function developProject(
       signal,
       latestUserMessageId: userMessageId,
       allowCustomStrategy,
+      roundId,
+      roundCount,
     },
     appConfig.networkAccessEnabled,
   )
@@ -596,13 +600,20 @@ async function initializeContextDebugContext(
         conversation.agentMessages.filter((message) => message.contextLayer !== 'warm'),
       )
     : await readConversationMessages(projectId, conversationId)
-  const managed = buildAgentContext(project, modelConfig, contextConfig, history, appConfig.networkAccessEnabled, { allow: appConfig.developerMode && conversation.contextConfigOverride !== null })
-  const snapshot = buildContextDebugSnapshot(managed, contextConfig, randomUUID(), randomUUID())
+  const initializationRoundId = randomUUID()
+  const initializationRoundCount = conversation.agentMessages.filter((message) => message.role === 'user').length
+  const managed = buildAgentContext(project, modelConfig, contextConfig, history, appConfig.networkAccessEnabled, {
+    allow: appConfig.developerMode && conversation.contextConfigOverride !== null,
+    roundId: initializationRoundId,
+    roundCount: initializationRoundCount,
+  })
+  const snapshot = buildContextDebugSnapshot(managed, contextConfig, randomUUID(), initializationRoundId, initializationRoundCount)
   rememberInitializedSnapshot(
     projectId,
     conversationId,
     snapshot,
     [...managed.messages, ...managed.warmMessages],
+    managed.actions,
   )
 }
 async function openContextDebugWindow(projectId: string, conversationId: string): Promise<void> {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -91,6 +91,13 @@ export type PerformanceTraceScope = 'renderer' | 'main' | 'agent'
 
 export type PerformanceTraceValue = number | boolean | string | null
 
+export type ContextAction = {
+  type: 'promote' | 'demote' | 'summarize' | 'recall'
+  messageIds: string[]
+  truthRefs: string[]
+  tokenDelta?: number
+}
+
 export type PerformanceTraceEvent = {
   traceId: string
   scope: PerformanceTraceScope
@@ -306,6 +313,7 @@ export type ContextLayerItem = {
 export type ContextDebugSnapshot = {
   requestId: string
   roundId: string
+  roundCount: number
   createdAt: string
   modelMaxContext: number
   triggerThreshold: number
@@ -370,7 +378,9 @@ export type ContextAuditEvent = {
   projectId: string
   conversationId: string
   roundId?: string
+  roundCount?: number
   requestId?: string
+  truthRefs?: string[]
   type:
     | 'hot_to_warm'
     | 'warm_to_cold'


### PR DESCRIPTION
Track Cold recall, Hot promotion, Hot demotion, and Warm summarization with truth references. Recompute layered context budgets after bounded transitions while preserving complete tool-call units, and record conversation round counts in debug snapshots, audit events, and performance traces.